### PR TITLE
建议当Github OAuth登录的用户没有设置Github昵称时，使用id作为display_name。

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -50,7 +50,7 @@ module.exports = class extends Base {
     
     return {
       id: userInfo.login,
-      name: userInfo.name,
+      name: userInfo.name || userInfo.login,
       email: userInfo.email,
       url: userInfo.blog,
       avatar: userInfo.avatar_url,


### PR DESCRIPTION
否则，现在如果一个通过Github登录的用户没有设置昵称，他的名字就会变成null。

see https://github.com/walinejs/waline/pull/837 .

谢谢！